### PR TITLE
Update search_patterns.yaml

### DIFF
--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -325,7 +325,7 @@ eigenstratdatabasetools:
 fastp:
   fn: "*.json"
   contents: '"before_filtering": {'
-  num_lines: 3
+  num_lines: 5
 fastq_screen:
   fn: "*_screen.txt"
 fastqc/data:


### PR DESCRIPTION
In fastp v 0.23.4 the json report prints 5 lines before the "before_filtering" pattern shows up.

This commit ensures that fastp json files are detected by MultiQC.